### PR TITLE
fix(frontend): auth loading UX and private link token leak

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { CircularProgress } from "@mui/material";
 import { fetchUserinfo, loadOIDCSetup, type AuthUser, type OIDCSetup } from "./drivers/auth";
 import { Layout } from "./components/Layout";
 import { GlobalProvider } from "./contexts/global";
@@ -43,8 +44,16 @@ function App() {
     });
   }, []);
 
-  if (window.location.search.includes("code=") || user === undefined) {
+  if (window.location.search.includes("code=")) {
     return null;
+  }
+
+  if (user === undefined) {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <CircularProgress />
+      </div>
+    );
   }
 
   const getToken = async (): Promise<string | null> => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,7 +57,7 @@ function App() {
   }
 
   const getToken = async (): Promise<string | null> => {
-    if (!oidcSetup?.configured) return null;
+    if (!oidcSetup?.configured || user === null) return null;
     const u = await oidcSetup.userManager.getUser();
     return u?.access_token ?? null;
   };


### PR DESCRIPTION
## Summary

- 認証チェック中（`user === undefined`）に空白ページが表示されていた問題を修正。`CircularProgress` を表示するようにした
- 未認証状態（`user === null`）でも localStorage に有効なトークンが残っている場合、`getToken()` がそれを返してしまい、バックエンドが authenticated と判断してプライベートリンクを返していた問題を修正

## Test plan

- [ ] 未ログイン状態でトップページにアクセスし、ローディングスピナーが表示されることを確認
- [ ] ローディング完了後、Private: true のリンクが表示されないことを確認
- [ ] ログイン後、Private: true のリンクが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)