### PR TITLE
refactor(backend): replace per-request K8s API calls with Informer-backed cache

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/samber/lo v1.52.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/backend/internal/infrastructure/kubernetes/client.go
+++ b/backend/internal/infrastructure/kubernetes/client.go
@@ -9,15 +9,20 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elliotchance/orderedmap/v3"
 	"github.com/mattn/go-jsonpointer"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 
 	kubeportalv1alpha1 "github.com/ShotaKitazawa/kube-portal/internal/infrastructure/kubernetes/api/v1alpha1"
@@ -29,33 +34,61 @@ const ingressAnnotationPrefix = "kube-portal.kanatakita.com/"
 
 var ingressAnnotationMatcher *regexp.Regexp
 
+var externalLinkGVR = schema.GroupVersionResource{
+	Group:    kubeportalv1alpha1.GroupVersion.Group,
+	Version:  kubeportalv1alpha1.GroupVersion.Version,
+	Resource: "externallinks",
+}
+
 func init() {
 	ingressAnnotationMatcher = regexp.MustCompile(
 		`^rules\.(\d+)\.paths\.(\d+)\.(.+)$`)
 }
 
 type Client struct {
-	log       *slog.Logger
-	clientset kubernetes.Interface
-	dynamic   dynamic.Interface
+	log               *slog.Logger
+	ingressStore      cache.Store
+	externalLinkStore cache.Store
 }
 
 var _ port.Kubernetes = (*Client)(nil)
 
-func NewClient(logger *slog.Logger, kubeconfigPath string) (*Client, error) {
+func NewClient(ctx context.Context, logger *slog.Logger, kubeconfigPath string) (*Client, error) {
 	kubeConfig, err := buildConfig(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
-	client, err := kubernetes.NewForConfig(kubeConfig)
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	dynamic, err := dynamic.NewForConfig(kubeConfig)
+	dynClient, err := dynamic.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{logger, client, dynamic}, nil
+
+	stopCh := ctx.Done()
+
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	ingressInformer := factory.Networking().V1().Ingresses().Informer()
+
+	dynFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynClient, 0)
+	externalLinkInformer := dynFactory.ForResource(externalLinkGVR).Informer()
+
+	factory.Start(stopCh)
+	dynFactory.Start(stopCh)
+
+	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if !cache.WaitForCacheSync(syncCtx.Done(), ingressInformer.HasSynced, externalLinkInformer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for caches to sync")
+	}
+
+	return &Client{
+		log:               logger,
+		ingressStore:      ingressInformer.GetStore(),
+		externalLinkStore: externalLinkInformer.GetStore(),
+	}, nil
 }
 
 func buildConfig(kubeconfig string) (*rest.Config, error) {
@@ -73,14 +106,15 @@ func buildConfig(kubeconfig string) (*rest.Config, error) {
 	return cfg, nil
 }
 
-func (c *Client) ListIngress(ctx context.Context) (model.LinkList, error) {
-	ings, err := c.clientset.NetworkingV1().Ingresses("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) ListIngress(_ context.Context) (model.LinkList, error) {
 	var result model.LinkList
-	for _, ing := range ings.Items {
+	for _, item := range c.ingressStore.List() {
+		ing, ok := item.(*networkingv1.Ingress)
+		if !ok {
+			c.log.Warn("unexpected object type in ingress store")
+			continue
+		}
+
 		m := orderedmap.NewOrderedMap[string, model.Link]()
 		logger := c.log.With(
 			slog.String("name", ing.Name),
@@ -196,33 +230,32 @@ func (c *Client) ListIngress(ctx context.Context) (model.LinkList, error) {
 	return result, nil
 }
 
-func (c *Client) ListExternalLink(ctx context.Context) (model.LinkList, error) {
-	gvr := schema.GroupVersionResource{
-		Group:    kubeportalv1alpha1.GroupVersion.Group,
-		Version:  kubeportalv1alpha1.GroupVersion.Version,
-		Resource: "externallinks",
-	}
-	uList, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
+func (c *Client) ListExternalLink(_ context.Context) (model.LinkList, error) {
+	if c.externalLinkStore == nil {
+		return nil, nil
 	}
 	var result []model.Link
-	for _, u := range uList.Items {
+	for _, item := range c.externalLinkStore.List() {
+		u, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			c.log.Warn("unexpected object type in external link store")
+			continue
+		}
 		exLink := kubeportalv1alpha1.ExternalLink{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &exLink); err != nil {
 			return nil, err
 		}
 		/* get & validate values */
-		u, err := url.Parse(exLink.Spec.Href)
+		href, err := url.Parse(exLink.Spec.Href)
 		if err != nil {
 			return nil, err
 		}
 		/* set values to result */
 		result = append(result, model.Link{
 			Name:      exLink.Spec.Title,
-			Hostname:  u.Host,
-			Path:      u.Path,
-			Proto:     u.Scheme,
+			Hostname:  href.Host,
+			Path:      href.Path,
+			Proto:     href.Scheme,
 			IconUrl:   exLink.Spec.IconURL,
 			Tags:      exLink.Spec.Tags,
 			IsPrivate: exLink.Spec.IsPrivate,

--- a/backend/internal/infrastructure/kubernetes/client_test.go
+++ b/backend/internal/infrastructure/kubernetes/client_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/ShotaKitazawa/kube-portal/internal/model"
+	"github.com/google/go-cmp/cmp"
 )
 
 func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
@@ -33,10 +33,10 @@ func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
 
 func TestClient_ListIngress(t *testing.T) {
 	tests := []struct {
-		name     string
+		name      string
 		ingresses []*networkingv1.Ingress
-		want     model.LinkList
-		wantErr  bool
+		want      model.LinkList
+		wantErr   bool
 	}{
 		{
 			name: "testcase 01",

--- a/backend/internal/infrastructure/kubernetes/client_test.go
+++ b/backend/internal/infrastructure/kubernetes/client_test.go
@@ -8,55 +8,61 @@ import (
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
 
-	"github.com/ShotaKitazawa/kube-portal/internal/model"
 	"github.com/google/go-cmp/cmp"
+	"github.com/ShotaKitazawa/kube-portal/internal/model"
 )
 
-func TestClient_ListIngressInfo(t *testing.T) {
-	type fields struct {
-		clientset kubernetes.Interface
+func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
+	ingressStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, o := range ingressObjs {
+		ingressStore.Add(o)
 	}
-	type args struct {
-		ctx context.Context
+	externalLinkStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, o := range externalLinkObjs {
+		externalLinkStore.Add(o)
 	}
+	return &Client{
+		log:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		ingressStore:      ingressStore,
+		externalLinkStore: externalLinkStore,
+	}
+}
+
+func TestClient_ListIngress(t *testing.T) {
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    model.LinkList
-		wantErr bool
+		name     string
+		ingresses []*networkingv1.Ingress
+		want     model.LinkList
+		wantErr  bool
 	}{
 		{
 			name: "testcase 01",
-			fields: fields{
-				fake.NewSimpleClientset(
-					&networkingv1.Ingress{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test01",
-							Namespace: "default",
-							Annotations: map[string]string{
-								"kube-portal.kanatakita.com/rules.0.paths.0.enable": "true",
-							},
-						},
-						Spec: networkingv1.IngressSpec{
-							Rules: []networkingv1.IngressRule{{
-								Host: "01.example.com",
-								IngressRuleValue: networkingv1.IngressRuleValue{
-									HTTP: &networkingv1.HTTPIngressRuleValue{
-										Paths: []networkingv1.HTTPIngressPath{{
-											Path: "/",
-										}},
-									},
-								},
-							}},
+			ingresses: []*networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test01",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"kube-portal.kanatakita.com/rules.0.paths.0.enable": "true",
 						},
 					},
-				),
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{{
+							Host: "01.example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path: "/",
+									}},
+								},
+							},
+						}},
+					},
+				},
 			},
-			args: args{context.Background()},
 			want: model.LinkList{
 				{
 					Name:      "test01",
@@ -75,17 +81,80 @@ func TestClient_ListIngressInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Client{
-				log:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
-				clientset: tt.fields.clientset,
+			objs := make([]any, len(tt.ingresses))
+			for i, ing := range tt.ingresses {
+				objs[i] = ing
 			}
-			got, err := c.ListIngress(tt.args.ctx)
+			c := newClient(objs, nil)
+			got, err := c.ListIngress(context.Background())
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Client.ListIngressInfo() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Client.ListIngress() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("the result of Client.ListIngressInfo() is unexpected: %s", diff)
+				t.Errorf("the result of Client.ListIngress() is unexpected: %s", diff)
+			}
+		})
+	}
+}
+
+func TestClient_ListExternalLink(t *testing.T) {
+	tests := []struct {
+		name          string
+		externalLinks []*unstructured.Unstructured
+		want          model.LinkList
+		wantErr       bool
+	}{
+		{
+			name: "basic external link",
+			externalLinks: []*unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "kubeportal.kanatakita.com/v1alpha1",
+						"kind":       "ExternalLink",
+						"metadata": map[string]any{
+							"name":      "test-link",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"title":     "Test Link",
+							"href":      "https://example.com/app",
+							"iconURL":   "https://example.com/icon.png",
+							"tags":      []any{"prod"},
+							"isPrivate": false,
+						},
+					},
+				},
+			},
+			want: model.LinkList{
+				{
+					Name:      "Test Link",
+					Hostname:  "example.com",
+					Path:      "/app",
+					Proto:     "https",
+					IconUrl:   "https://example.com/icon.png",
+					Tags:      []string{"prod"},
+					IsPrivate: false,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]any, len(tt.externalLinks))
+			for i, el := range tt.externalLinks {
+				objs[i] = el
+			}
+			c := newClient(nil, objs)
+			got, err := c.ListExternalLink(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.ListExternalLink() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("the result of Client.ListExternalLink() is unexpected: %s", diff)
 			}
 		})
 	}

--- a/backend/route.go
+++ b/backend/route.go
@@ -28,7 +28,7 @@ func Run(ctx context.Context, cmd *cli.Command) error {
 	}))
 
 	// New Clients
-	k8sClient, err := kubernetes.NewClient(logger, cmd.String(flag.KubeConfigPath.Name))
+	k8sClient, err := kubernetes.NewClient(ctx, logger, cmd.String(flag.KubeConfigPath.Name))
 	if err != nil {
 		return fmt.Errorf("failed to initialize k8s client: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `ListIngress` と `ListExternalLink` がリクエストごとに K8s API サーバーへ `List` を発行していた問題を解消
- `SharedInformerFactory` (Ingress) と `DynamicSharedInformerFactory` (ExternalLink) を使ってインメモリ Store を維持するよう変更
- `NewClient` は起動時にインフォーマーを開始し、最大 30 秒間キャッシュ同期を待ってから返す
- テストは `cache.NewStore` で Store を直接構築する方式に移行し、fake clientset への依存を排除。`ListExternalLink` のテストも新規追加

## 効果

- ポーリング × ユーザー数に比例して増加していた API サーバー負荷が排除される
- `/api/list` のレスポンスレイテンシがキャッシュ読み取り（メモリ）に改善される
- Watch によりクラスタ変更がキャッシュへリアルタイム反映される（次 PR でのSSE化の布石）

## Test plan

- [ ] `mise run test-backend` がすべて通過すること
- [ ] `mise run ci` でビルド・Lint が通過すること
- [ ] クラスタ環境で起動し、`/api/list` が従来通りリンクを返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)