### PR TITLE
feat(backend): add Gateway API HTTPRoute support

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/samber/lo v1.52.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -102,7 +102,11 @@ func (h *Handler) ListIngressInfo(ctx context.Context) ([]api.IngressInfo, error
 	if err != nil {
 		return nil, err
 	}
-	links := append(res1, res2...).ExcludePrivateLinkIfNotLogIn(isLogin)
+	res3, err := h.k8sClient.ListHTTPRoute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	links := append(append(res1, res2...), res3...).ExcludePrivateLinkIfNotLogIn(isLogin)
 
 	return toIngressInfoList(links, h.showUntaggedLinks), nil
 }

--- a/backend/internal/infrastructure/kubernetes/client.go
+++ b/backend/internal/infrastructure/kubernetes/client.go
@@ -40,6 +40,12 @@ var externalLinkGVR = schema.GroupVersionResource{
 	Resource: "externallinks",
 }
 
+var httpRouteGVR = schema.GroupVersionResource{
+	Group:    "gateway.networking.k8s.io",
+	Version:  "v1",
+	Resource: "httproutes",
+}
+
 func init() {
 	ingressAnnotationMatcher = regexp.MustCompile(
 		`^rules\.(\d+)\.paths\.(\d+)\.(.+)$`)
@@ -49,6 +55,7 @@ type Client struct {
 	log               *slog.Logger
 	ingressStore      cache.Store
 	externalLinkStore cache.Store
+	httprouteStore    cache.Store // nil when Gateway API CRD is not installed
 }
 
 var _ port.Kubernetes = (*Client)(nil)
@@ -75,20 +82,37 @@ func NewClient(ctx context.Context, logger *slog.Logger, kubeconfigPath string) 
 	dynFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynClient, 0)
 	externalLinkInformer := dynFactory.ForResource(externalLinkGVR).Informer()
 
+	// Detect Gateway API availability; skip HTTPRoute informer if CRD is absent
+	var httpRouteInformer cache.SharedIndexInformer
+	if _, err := clientset.Discovery().ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1"); err != nil {
+		logger.Warn("gateway.networking.k8s.io/v1 not available, HTTPRoute support disabled", "error", err)
+	} else {
+		httpRouteInformer = dynFactory.ForResource(httpRouteGVR).Informer()
+	}
+
 	factory.Start(stopCh)
 	dynFactory.Start(stopCh)
 
+	toSync := []cache.InformerSynced{ingressInformer.HasSynced, externalLinkInformer.HasSynced}
+	if httpRouteInformer != nil {
+		toSync = append(toSync, httpRouteInformer.HasSynced)
+	}
+
 	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if !cache.WaitForCacheSync(syncCtx.Done(), ingressInformer.HasSynced, externalLinkInformer.HasSynced) {
+	if !cache.WaitForCacheSync(syncCtx.Done(), toSync...) {
 		return nil, fmt.Errorf("timed out waiting for caches to sync")
 	}
 
-	return &Client{
+	c := &Client{
 		log:               logger,
 		ingressStore:      ingressInformer.GetStore(),
 		externalLinkStore: externalLinkInformer.GetStore(),
-	}, nil
+	}
+	if httpRouteInformer != nil {
+		c.httprouteStore = httpRouteInformer.GetStore()
+	}
+	return c, nil
 }
 
 func buildConfig(kubeconfig string) (*rest.Config, error) {
@@ -227,6 +251,119 @@ func (c *Client) ListIngress(_ context.Context) (model.LinkList, error) {
 		}
 	}
 
+	return result, nil
+}
+
+func (c *Client) ListHTTPRoute(_ context.Context) (model.LinkList, error) {
+	if c.httprouteStore == nil {
+		return nil, nil
+	}
+	var result model.LinkList
+	for _, item := range c.httprouteStore.List() {
+		u, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			c.log.Warn("unexpected object type in httproute store")
+			continue
+		}
+
+		m := orderedmap.NewOrderedMap[string, model.Link]()
+		logger := c.log.With(
+			slog.String("name", u.GetName()),
+			slog.String("namespace", u.GetNamespace()),
+		)
+
+		specBytes, err := json.Marshal(u.Object["spec"])
+		if err != nil {
+			return nil, err
+		}
+		var specObj interface{}
+		if err := json.Unmarshal(specBytes, &specObj); err != nil {
+			return nil, err
+		}
+
+		for key, val := range u.GetAnnotations() {
+			logger = logger.With(slog.String("annotation", key))
+			if !strings.HasPrefix(key, ingressAnnotationPrefix) {
+				continue
+			}
+			key = strings.TrimPrefix(key, ingressAnnotationPrefix)
+
+			l := ingressAnnotationMatcher.FindStringSubmatch(key)
+			if len(l) != 4 {
+				logger.Warn("skip: annotation didn't match the matcher")
+				continue
+			}
+			ruleIdx, _ := strconv.Atoi(l[1])
+			pathIdx, _ := strconv.Atoi(l[2])
+			action := l[3]
+
+			tmpLink, _ := m.Get(fmt.Sprintf("%d-%d", ruleIdx, pathIdx))
+			switch action {
+			case "enable":
+				// pass
+			case "name":
+				tmpLink.Name = val
+			case "proto":
+				tmpLink.Proto = val
+			case "icon-url":
+				tmpLink.IconUrl = val
+			case "tags":
+				tmpLink.Tags = strings.Split(val, ",")
+			case "is-private":
+				if strings.ToLower(val) == "true" {
+					tmpLink.IsPrivate = true
+				}
+			default:
+				logger.Warn("skip: annotation is not supported")
+				continue
+			}
+
+			// HTTPRoute: hostname is global (spec.hostnames[0]), not per-rule
+			if tmpLink.Hostname == "" {
+				rv, err := jsonpointer.Get(specObj, "/hostnames/0")
+				if err != nil {
+					logger.Warn("skip: HTTPRoute spec.hostnames[0] is empty")
+					continue
+				}
+				hostname, ok := rv.(string)
+				if !ok {
+					logger.Warn("skip: HTTPRoute spec.hostnames[0] is empty")
+					continue
+				}
+				tmpLink.Hostname = hostname
+			}
+			// Path: spec.rules[ruleIdx].matches[pathIdx].path.value
+			if tmpLink.Path == "" {
+				rv, err := jsonpointer.Get(specObj,
+					fmt.Sprintf("/rules/%d/matches/%d/path/value", ruleIdx, pathIdx))
+				if err != nil {
+					logger.Debug(fmt.Sprintf(
+						"HTTPRoute spec.rules[%d].matches[%d].path.value is empty: use / as path",
+						ruleIdx, pathIdx))
+					tmpLink.Path = "/"
+				} else if path, ok := rv.(string); ok {
+					tmpLink.Path = path
+				} else {
+					tmpLink.Path = "/"
+				}
+			}
+			m.Set(fmt.Sprintf("%d-%d", ruleIdx, pathIdx), tmpLink)
+		}
+
+		for key := range m.Keys() {
+			val, _ := m.Get(key)
+			if val.Name == "" {
+				val.Name = u.GetName()
+			}
+			if val.Proto == "" {
+				val.Proto = "https"
+			}
+			if val.Tags == nil {
+				val.Tags = []string{}
+			}
+			result = append(result, val)
+		}
+	}
 	return result, nil
 }
 

--- a/backend/internal/infrastructure/kubernetes/client.go
+++ b/backend/internal/infrastructure/kubernetes/client.go
@@ -9,15 +9,20 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elliotchance/orderedmap/v3"
 	"github.com/mattn/go-jsonpointer"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 
 	kubeportalv1alpha1 "github.com/ShotaKitazawa/kube-portal/internal/infrastructure/kubernetes/api/v1alpha1"
@@ -29,33 +34,61 @@ const ingressAnnotationPrefix = "kube-portal.kanatakita.com/"
 
 var ingressAnnotationMatcher *regexp.Regexp
 
+var externalLinkGVR = schema.GroupVersionResource{
+	Group:    kubeportalv1alpha1.GroupVersion.Group,
+	Version:  kubeportalv1alpha1.GroupVersion.Version,
+	Resource: "externallinks",
+}
+
 func init() {
 	ingressAnnotationMatcher = regexp.MustCompile(
 		`^rules\.(\d+)\.paths\.(\d+)\.(.+)$`)
 }
 
 type Client struct {
-	log       *slog.Logger
-	clientset kubernetes.Interface
-	dynamic   dynamic.Interface
+	log               *slog.Logger
+	ingressStore      cache.Store
+	externalLinkStore cache.Store
 }
 
 var _ port.Kubernetes = (*Client)(nil)
 
-func NewClient(logger *slog.Logger, kubeconfigPath string) (*Client, error) {
+func NewClient(ctx context.Context, logger *slog.Logger, kubeconfigPath string) (*Client, error) {
 	kubeConfig, err := buildConfig(kubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
-	client, err := kubernetes.NewForConfig(kubeConfig)
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	dynamic, err := dynamic.NewForConfig(kubeConfig)
+	dynClient, err := dynamic.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{logger, client, dynamic}, nil
+
+	stopCh := ctx.Done()
+
+	factory := informers.NewSharedInformerFactory(clientset, 0)
+	ingressInformer := factory.Networking().V1().Ingresses().Informer()
+
+	dynFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynClient, 0)
+	externalLinkInformer := dynFactory.ForResource(externalLinkGVR).Informer()
+
+	factory.Start(stopCh)
+	dynFactory.Start(stopCh)
+
+	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if !cache.WaitForCacheSync(syncCtx.Done(), ingressInformer.HasSynced, externalLinkInformer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for caches to sync")
+	}
+
+	return &Client{
+		log:               logger,
+		ingressStore:      ingressInformer.GetStore(),
+		externalLinkStore: externalLinkInformer.GetStore(),
+	}, nil
 }
 
 func buildConfig(kubeconfig string) (*rest.Config, error) {
@@ -73,14 +106,15 @@ func buildConfig(kubeconfig string) (*rest.Config, error) {
 	return cfg, nil
 }
 
-func (c *Client) ListIngress(ctx context.Context) (model.LinkList, error) {
-	ings, err := c.clientset.NetworkingV1().Ingresses("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
+func (c *Client) ListIngress(_ context.Context) (model.LinkList, error) {
 	var result model.LinkList
-	for _, ing := range ings.Items {
+	for _, item := range c.ingressStore.List() {
+		ing, ok := item.(*networkingv1.Ingress)
+		if !ok {
+			c.log.Warn("unexpected object type in ingress store")
+			continue
+		}
+
 		m := orderedmap.NewOrderedMap[string, model.Link]()
 		logger := c.log.With(
 			slog.String("name", ing.Name),
@@ -196,33 +230,32 @@ func (c *Client) ListIngress(ctx context.Context) (model.LinkList, error) {
 	return result, nil
 }
 
-func (c *Client) ListExternalLink(ctx context.Context) (model.LinkList, error) {
-	gvr := schema.GroupVersionResource{
-		Group:    kubeportalv1alpha1.GroupVersion.Group,
-		Version:  kubeportalv1alpha1.GroupVersion.Version,
-		Resource: "externallinks",
-	}
-	uList, err := c.dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
+func (c *Client) ListExternalLink(_ context.Context) (model.LinkList, error) {
+	if c.externalLinkStore == nil {
+		return nil, nil
 	}
 	var result []model.Link
-	for _, u := range uList.Items {
+	for _, item := range c.externalLinkStore.List() {
+		u, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			c.log.Warn("unexpected object type in external link store")
+			continue
+		}
 		exLink := kubeportalv1alpha1.ExternalLink{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &exLink); err != nil {
 			return nil, err
 		}
 		/* get & validate values */
-		u, err := url.Parse(exLink.Spec.Href)
+		href, err := url.Parse(exLink.Spec.Href)
 		if err != nil {
 			return nil, err
 		}
 		/* set values to result */
 		result = append(result, model.Link{
 			Name:      exLink.Spec.Title,
-			Hostname:  u.Host,
-			Path:      u.Path,
-			Proto:     u.Scheme,
+			Hostname:  href.Host,
+			Path:      href.Path,
+			Proto:     href.Scheme,
 			IconUrl:   exLink.Spec.IconURL,
 			Tags:      exLink.Spec.Tags,
 			IsPrivate: exLink.Spec.IsPrivate,

--- a/backend/internal/infrastructure/kubernetes/client_test.go
+++ b/backend/internal/infrastructure/kubernetes/client_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/ShotaKitazawa/kube-portal/internal/model"
+	"github.com/google/go-cmp/cmp"
 )
 
 func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
@@ -33,10 +33,10 @@ func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
 
 func TestClient_ListIngress(t *testing.T) {
 	tests := []struct {
-		name     string
+		name      string
 		ingresses []*networkingv1.Ingress
-		want     model.LinkList
-		wantErr  bool
+		want      model.LinkList
+		wantErr   bool
 	}{
 		{
 			name: "testcase 01",

--- a/backend/internal/infrastructure/kubernetes/client_test.go
+++ b/backend/internal/infrastructure/kubernetes/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
+func newClient(ingressObjs, externalLinkObjs, httprouteObjs []any) *Client {
 	ingressStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	for _, o := range ingressObjs {
 		ingressStore.Add(o)
@@ -24,11 +24,19 @@ func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
 	for _, o := range externalLinkObjs {
 		externalLinkStore.Add(o)
 	}
-	return &Client{
+	c := &Client{
 		log:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		ingressStore:      ingressStore,
 		externalLinkStore: externalLinkStore,
 	}
+	if httprouteObjs != nil {
+		httprouteStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+		for _, o := range httprouteObjs {
+			httprouteStore.Add(o)
+		}
+		c.httprouteStore = httprouteStore
+	}
+	return c
 }
 
 func TestClient_ListIngress(t *testing.T) {
@@ -85,7 +93,7 @@ func TestClient_ListIngress(t *testing.T) {
 			for i, ing := range tt.ingresses {
 				objs[i] = ing
 			}
-			c := newClient(objs, nil)
+			c := newClient(objs, nil, nil)
 			got, err := c.ListIngress(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client.ListIngress() error = %v, wantErr %v", err, tt.wantErr)
@@ -147,7 +155,7 @@ func TestClient_ListExternalLink(t *testing.T) {
 			for i, el := range tt.externalLinks {
 				objs[i] = el
 			}
-			c := newClient(nil, objs)
+			c := newClient(nil, objs, nil)
 			got, err := c.ListExternalLink(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client.ListExternalLink() error = %v, wantErr %v", err, tt.wantErr)
@@ -155,6 +163,90 @@ func TestClient_ListExternalLink(t *testing.T) {
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("the result of Client.ListExternalLink() is unexpected: %s", diff)
+			}
+		})
+	}
+}
+
+func TestClient_ListHTTPRoute(t *testing.T) {
+	tests := []struct {
+		name        string
+		httproutes  []*unstructured.Unstructured
+		wantNil     bool // nil httprouteStore (Gateway API absent)
+		want        model.LinkList
+		wantErr     bool
+	}{
+		{
+			name:    "returns nil when Gateway API is not available",
+			wantNil: true,
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "basic httproute",
+			httproutes: []*unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "gateway.networking.k8s.io/v1",
+						"kind":       "HTTPRoute",
+						"metadata": map[string]any{
+							"name":      "test-route",
+							"namespace": "default",
+							"annotations": map[string]any{
+								"kube-portal.kanatakita.com/rules.0.paths.0.enable": "true",
+								"kube-portal.kanatakita.com/rules.0.paths.0.name":   "My App",
+							},
+						},
+						"spec": map[string]any{
+							"hostnames": []any{"app.example.com"},
+							"rules": []any{
+								map[string]any{
+									"matches": []any{
+										map[string]any{
+											"path": map[string]any{
+												"type":  "PathPrefix",
+												"value": "/app",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: model.LinkList{
+				{
+					Name:      "My App",
+					Hostname:  "app.example.com",
+					Path:      "/app",
+					Proto:     "https",
+					IconUrl:   "",
+					Tags:      []string{},
+					IsPrivate: false,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var httprouteObjs []any
+			if !tt.wantNil {
+				httprouteObjs = make([]any, len(tt.httproutes))
+				for i, r := range tt.httproutes {
+					httprouteObjs[i] = r
+				}
+			}
+			c := newClient(nil, nil, httprouteObjs)
+			got, err := c.ListHTTPRoute(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.ListHTTPRoute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("the result of Client.ListHTTPRoute() is unexpected: %s", diff)
 			}
 		})
 	}

--- a/backend/internal/infrastructure/kubernetes/client_test.go
+++ b/backend/internal/infrastructure/kubernetes/client_test.go
@@ -170,11 +170,11 @@ func TestClient_ListExternalLink(t *testing.T) {
 
 func TestClient_ListHTTPRoute(t *testing.T) {
 	tests := []struct {
-		name        string
-		httproutes  []*unstructured.Unstructured
-		wantNil     bool // nil httprouteStore (Gateway API absent)
-		want        model.LinkList
-		wantErr     bool
+		name       string
+		httproutes []*unstructured.Unstructured
+		wantNil    bool // nil httprouteStore (Gateway API absent)
+		want       model.LinkList
+		wantErr    bool
 	}{
 		{
 			name:    "returns nil when Gateway API is not available",

--- a/backend/internal/infrastructure/kubernetes/client_test.go
+++ b/backend/internal/infrastructure/kubernetes/client_test.go
@@ -8,55 +8,61 @@ import (
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
 
-	"github.com/ShotaKitazawa/kube-portal/internal/model"
 	"github.com/google/go-cmp/cmp"
+	"github.com/ShotaKitazawa/kube-portal/internal/model"
 )
 
-func TestClient_ListIngressInfo(t *testing.T) {
-	type fields struct {
-		clientset kubernetes.Interface
+func newClient(ingressObjs []any, externalLinkObjs []any) *Client {
+	ingressStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, o := range ingressObjs {
+		ingressStore.Add(o)
 	}
-	type args struct {
-		ctx context.Context
+	externalLinkStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	for _, o := range externalLinkObjs {
+		externalLinkStore.Add(o)
 	}
+	return &Client{
+		log:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		ingressStore:      ingressStore,
+		externalLinkStore: externalLinkStore,
+	}
+}
+
+func TestClient_ListIngress(t *testing.T) {
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    model.LinkList
-		wantErr bool
+		name     string
+		ingresses []*networkingv1.Ingress
+		want     model.LinkList
+		wantErr  bool
 	}{
 		{
 			name: "testcase 01",
-			fields: fields{
-				fake.NewSimpleClientset(
-					&networkingv1.Ingress{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test01",
-							Namespace: "default",
-							Annotations: map[string]string{
-								"kube-portal.kanatakita.com/rules.0.paths.0.enable": "true",
-							},
-						},
-						Spec: networkingv1.IngressSpec{
-							Rules: []networkingv1.IngressRule{{
-								Host: "01.example.com",
-								IngressRuleValue: networkingv1.IngressRuleValue{
-									HTTP: &networkingv1.HTTPIngressRuleValue{
-										Paths: []networkingv1.HTTPIngressPath{{
-											Path: "/",
-										}},
-									},
-								},
-							}},
+			ingresses: []*networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test01",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"kube-portal.kanatakita.com/rules.0.paths.0.enable": "true",
 						},
 					},
-				),
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{{
+							Host: "01.example.com",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path: "/",
+									}},
+								},
+							},
+						}},
+					},
+				},
 			},
-			args: args{context.Background()},
 			want: model.LinkList{
 				{
 					Name:      "test01",
@@ -75,17 +81,80 @@ func TestClient_ListIngressInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Client{
-				log:       slog.New(slog.NewJSONHandler(io.Discard, nil)),
-				clientset: tt.fields.clientset,
+			objs := make([]any, len(tt.ingresses))
+			for i, ing := range tt.ingresses {
+				objs[i] = ing
 			}
-			got, err := c.ListIngress(tt.args.ctx)
+			c := newClient(objs, nil)
+			got, err := c.ListIngress(context.Background())
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Client.ListIngressInfo() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Client.ListIngress() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("the result of Client.ListIngressInfo() is unexpected: %s", diff)
+				t.Errorf("the result of Client.ListIngress() is unexpected: %s", diff)
+			}
+		})
+	}
+}
+
+func TestClient_ListExternalLink(t *testing.T) {
+	tests := []struct {
+		name          string
+		externalLinks []*unstructured.Unstructured
+		want          model.LinkList
+		wantErr       bool
+	}{
+		{
+			name: "basic external link",
+			externalLinks: []*unstructured.Unstructured{
+				{
+					Object: map[string]any{
+						"apiVersion": "kubeportal.kanatakita.com/v1alpha1",
+						"kind":       "ExternalLink",
+						"metadata": map[string]any{
+							"name":      "test-link",
+							"namespace": "default",
+						},
+						"spec": map[string]any{
+							"title":     "Test Link",
+							"href":      "https://example.com/app",
+							"iconURL":   "https://example.com/icon.png",
+							"tags":      []any{"prod"},
+							"isPrivate": false,
+						},
+					},
+				},
+			},
+			want: model.LinkList{
+				{
+					Name:      "Test Link",
+					Hostname:  "example.com",
+					Path:      "/app",
+					Proto:     "https",
+					IconUrl:   "https://example.com/icon.png",
+					Tags:      []string{"prod"},
+					IsPrivate: false,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]any, len(tt.externalLinks))
+			for i, el := range tt.externalLinks {
+				objs[i] = el
+			}
+			c := newClient(nil, objs)
+			got, err := c.ListExternalLink(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.ListExternalLink() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("the result of Client.ListExternalLink() is unexpected: %s", diff)
 			}
 		})
 	}

--- a/backend/internal/model/port/kubernetes.go
+++ b/backend/internal/model/port/kubernetes.go
@@ -9,4 +9,5 @@ import (
 type Kubernetes interface {
 	ListIngress(ctx context.Context) (model.LinkList, error)
 	ListExternalLink(ctx context.Context) (model.LinkList, error)
+	ListHTTPRoute(ctx context.Context) (model.LinkList, error)
 }

--- a/backend/route.go
+++ b/backend/route.go
@@ -28,7 +28,7 @@ func Run(ctx context.Context, cmd *cli.Command) error {
 	}))
 
 	// New Clients
-	k8sClient, err := kubernetes.NewClient(logger, cmd.String(flag.KubeConfigPath.Name))
+	k8sClient, err := kubernetes.NewClient(ctx, logger, cmd.String(flag.KubeConfigPath.Name))
 	if err != nil {
 		return fmt.Errorf("failed to initialize k8s client: %w", err)
 	}

--- a/manifests/role/clusterrole.yaml
+++ b/manifests/role/clusterrole.yaml
@@ -22,4 +22,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - get
+  - list
+  - watch
 


### PR DESCRIPTION
## Summary

- `gateway.networking.k8s.io/v1` の `HTTPRoute` リソースを動的インフォーマーで読み込み、既存のアノテーション解析ロジックを流用して `ListHTTPRoute` を実装
- 起動時に Discovery API で Gateway API の有無を確認し、CRD が存在しない場合は Warning ログを出して無効化（サーバー起動は継続）
- アノテーション体系は Ingress と同一 (`kube-portal.kanatakita.com/rules.<N>.paths.<M>.*`)
  - Hostname は `spec.hostnames[0]`、Path は `spec.rules[N].matches[M].path.value` から取得
- ClusterRole に `gateway.networking.k8s.io/httproutes` の `get/list/watch` を追加

## Depends on

#1078

## Test plan

- [ ] `mise run test-backend` がすべて通過すること
- [ ] Gateway API CRD **なし** の環境: 起動時に Warning ログが出て、HTTPRoute なしで正常動作すること
- [ ] Gateway API CRD **あり** の環境: アノテーションを付けた HTTPRoute がポータルにリンクとして表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)